### PR TITLE
fix AppVeyor failure in PR#126

### DIFF
--- a/test.js
+++ b/test.js
@@ -1287,7 +1287,7 @@ describe('workerpool', function() {
         // find all worker processes
         ps.lookup({
           command: 'node',
-          arguments: 'broccoli-babel-transpiler/lib/worker.js',
+          arguments: path.join('broccoli-babel-transpiler', 'lib', 'worker.js'),
         }, function(err, resultList ) {
           expect(err).to.eql(null);
           expect(resultList.length).to.eql(2);


### PR DESCRIPTION
AppVeyor CI fails for babel/broccoli-babel-transpiler#126 because it cannot find the processes from the worker pool. (It finds 0 processes instead of the expected 2.) The same test succeeds via Travis CI.

This leads me to believe that the path separator is at fault. Using `path.join` instead of forward slashes should resolve the issue.